### PR TITLE
container-build: install python-docker

### DIFF
--- a/roles/container-build/defaults/main.yml
+++ b/roles/container-build/defaults/main.yml
@@ -23,6 +23,12 @@ container_registry: 127.0.0.1:8787
 container_namespace: master
 container_push: True
 
+python_docker_package_name:
+  python2:
+    - python-docker
+  python3:
+    - python3-docker
+
 python_libselinux_package_name:
   python2:
     - python-libselinux

--- a/roles/container-build/tasks/main.yml
+++ b/roles/container-build/tasks/main.yml
@@ -17,6 +17,7 @@
   become: true
   with_items:
     - "{{ python_libselinux_package_name[build_python_version] }}"
+    - "{{ python_docker_package_name[build_python_version] }}"
     - git
     - "{{ python_pip_package_name[build_python_version] }}"
     - "{{ tripleoclient_package_name[build_python_version] }}"


### PR DESCRIPTION
... it's not installed by default in fedora.